### PR TITLE
[KOB-52864] Fix proxy framing: strip hop-by-hop headers, recompute Content-Length

### DIFF
--- a/src/templates/python/proxy_server.py
+++ b/src/templates/python/proxy_server.py
@@ -10,6 +10,11 @@ from constants import DEVICE_SOURCES
 # 15-minute timeout (matching Java)
 SOCKET_TIMEOUT_SECONDS = 15 * 60
 
+HOP_BY_HOP_HEADERS = frozenset({
+    'content-length', 'transfer-encoding', 'connection', 'keep-alive',
+    'proxy-connection', 'te', 'trailers', 'upgrade',
+})
+
 
 class ProxyHandler(BaseHTTPRequestHandler):
     server_instance = None
@@ -174,16 +179,14 @@ class ProxyHandler(BaseHTTPRequestHandler):
                 response_body = response.content
 
             try:
-                # Send response back with status code, headers and body
-                self.send_response(response.status_code)
-
-                # Strip Content-Length header since response_body may have been modified
-                # The HTTP server will calculate the correct length
                 response_headers = {key: val for key, val in response.headers.items()
-                                  if key.lower() != 'content-length'}
+                                  if key.lower() not in HOP_BY_HOP_HEADERS}
 
+                self.send_response(response.status_code)
                 for key, val in response_headers.items():
                     self.send_header(key, val)
+                self.send_header('Content-Length', str(len(response_body)))
+                self.send_header('Connection', 'close')
                 self.end_headers()
                 self.wfile.write(response_body)
             except Exception as send_error:


### PR DESCRIPTION
## Summary
- Generated Python pytest proxy was forwarding `Connection: keep-alive` without `Content-Length` or chunked framing, causing urllib3 to block indefinitely on response read after `POST /session`.
- Fix in `src/templates/python/proxy_server.py`: strip hop-by-hop headers (Content-Length, Transfer-Encoding, Connection, Keep-Alive, Proxy-Connection, TE, Trailers, Upgrade) from the upstream response, set `Content-Length` from the actual (possibly-rewritten) body bytes, and force `Connection: close`.
- Necessary because the response body can be rewritten in-flight (JSON Wire → W3C conversion for both `/session` and error responses), so the upstream `Content-Length` is no longer valid.

## Linked issue
[KOB-52864](https://kobiton.atlassian.net/browse/KOB-52864) — full root-cause analysis and pre/post-fix evidence is in the ticket comments.

## Why this is correct
- Hop-by-hop headers (RFC 7230 §6.1) must not be forwarded by an intermediary; the proxy was previously stripping only `Content-Length`.
- `Connection: close` keeps framing unambiguous for a single-request-per-connection proxy and avoids keep-alive reuse hazards when upstream and downstream framings disagree.

## Verification
- **Pre-fix (session 468671):** driver hung immediately after `POST /wd/hub/session 200`; zero further Appium commands; Kobiton ended the session with `state: TIMEOUT`, `endReason: USER-408`, `endMessage: \"Force end session by idling time out\"` after 16m 12.7s.
- **Post-fix (session 468672):** driver progressed cleanly through `POST /appium/settings`, `POST /context`, `POST /timeouts`, then 5+ recorded test commands (`POST /execute/sync`, `POST /element`, `GET .../displayed`, etc.) before hitting a separate XPath-locator issue tracked as KOB-52937. Clean `DELETE /session 200` on teardown.
- Patch was developed and verified against the generated bundle first; this PR ports the byte-identical patch back into the template.

## Test plan
- [ ] Regenerate a Python pytest bundle from this branch and run a smoke test against a Kobiton session
- [ ] Confirm proxy logs show `Content-Length` set to the post-rewrite body length
- [ ] Confirm `Connection: close` appears in forwarded response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOB-52864]: https://kobiton.atlassian.net/browse/KOB-52864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ