### PR TITLE
[KOB-53267] fix(python proxy): inject element id into empty click bodies

### DIFF
--- a/src/templates/python/proxy_server.py
+++ b/src/templates/python/proxy_server.py
@@ -153,6 +153,16 @@ class ProxyServer:
 
     def serve(self, request_uri, method, request_body):
         url, path = self._build_appium_url(request_uri)
+
+        # KOB-53267: Appium-Python-Client 3.x sends `POST .../click` with body
+        # `{}`; Java's older client sends `{"id":"<eid>"}`. Kobiton's
+        # flex-correct matches baseline commands by the legacy click body
+        # shape, so Python's empty body breaks the match -- flex-correct
+        # can't replay the dropped intermediate commands (KOB-53091). Inject
+        # the element id from the URL so the wire shape matches Java's.
+        if method == 'POST' and path.endswith('/click') and '/element/' in path:
+            request_body = self._inject_click_element_id(path, request_body)
+
         headers = {'Authorization': self._auth_string}
         # Appium upstream rejects bodied requests without a content type
         # ("desiredCapabilities or capabilities is required"). Match Java's
@@ -226,3 +236,23 @@ class ProxyServer:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(('', 0))
             return s.getsockname()[1]
+
+    @staticmethod
+    def _inject_click_element_id(path, request_body):
+        # Path may be either /wd/hub/session/{sid}/element/{eid}/click or
+        # /session/{sid}/element/{eid}/click depending on whether upstream
+        # base URL included /wd/hub. Locate 'element' segment by name.
+        parts = path.split('/')
+        try:
+            eid = parts[parts.index('element') + 1]
+        except (ValueError, IndexError):
+            return request_body
+        try:
+            raw = request_body.decode('utf-8') if isinstance(request_body, (bytes, bytearray)) else (request_body or '')
+            body = json.loads(raw) if raw.strip() else {}
+        except Exception:
+            return request_body
+        if not (isinstance(body, dict) and not body):
+            return request_body
+        new_body = json.dumps({'id': eid})
+        return new_body.encode('utf-8') if isinstance(request_body, (bytes, bytearray)) or request_body is None else new_body


### PR DESCRIPTION
## Summary

- Appium-Python-Client 3.x's `element.click()` sends `POST .../element/{eid}/click` with body `{}`. Java's `MobileElement.click()` sends `{"id":"<eid>"}`. Kobiton's flex-correct matches live commands against the baseline by the legacy id-in-body click shape, so Python's empty body breaks the match — flex-correct can't replay the dropped intermediate commands from [KOB-53091](https://kobiton.atlassian.net/browse/KOB-53091), Save Expense fires on an empty form, and the test fails at the next UI step.
- Fix intercepts `POST .../element/<eid>/click` in `ProxyServer.serve()` and rewrites empty `{}` bodies to `{"id":"<eid>"}` (extracting `eid` from the URL path). Java-shape bodies pass through unchanged.
- Closes [KOB-53267](https://kobiton.atlassian.net/browse/KOB-53267).

## Verification

All runs on baseline session **8671449**, Pixel 8 Pro / Android 16, `kobiton:flexCorrect=true`, no live-view portal-watching:

| Run | Session | type | click body | Result | Time |
|---|---|---|---|---|---|
| Java (control) | 8671457 | AUTO | `{"id":"…"}` | ✅ PASS | 17 s |
| Python pre-fix | 8672218 | AUTO | `{}` | ❌ FAIL @ Open Menu | 135 s |
| **Python with this patch** | **8672365** | **AUTO** | **`{"id":"…"}`** | **✅ PASS** | **19 s** |

Python now performs identically to Java end-to-end on the same baseline.

## Test plan

- [x] Verified the patched proxy rewrites the wire body to `{"id":"<eid>"}` via session 8672365's Appium log
- [x] End-to-end pytest run passes on a fresh export of baseline 8671449
- [x] Non-click endpoints (`/elements`, `/timeouts`, `/context`, `/source`, `/screenshot`, etc.) are unaffected — patch only triggers on `POST .../element/<eid>/click`
- [x] Java-shape click bodies (already containing `id`) pass through unchanged

## Notes

- See KOB-53267 for the full investigation trail. Earlier theories (W3C alwaysMatch leak, MIXED session classification) were ruled out in the comment history — actual cause is the click body shape mismatch.
- Long-term, server-side fix on Kobiton flex-correct's command matcher to accept both `{}` and `{"id":"…"}` would be the most correct fix — this PR is the contained workaround that ships today and unblocks generated Python pytest exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOB-53091]: https://kobiton.atlassian.net/browse/KOB-53091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KOB-53267]: https://kobiton.atlassian.net/browse/KOB-53267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ