### PR TITLE
[KOB-53267][KOB-53091] Wait for swipe/drag animation to settle before next command

### DIFF
--- a/src/templates/csharp/TestBase.cs
+++ b/src/templates/csharp/TestBase.cs
@@ -886,6 +886,9 @@ namespace AppiumTest
             sequence.AddAction(finger.CreatePointerUp(MouseButton.Left));
 
             driver.PerformActions(new List<ActionSequence> { sequence });
+            // PerformActions() returns as soon as the gesture is dispatched, but the swipe animation
+            // is still running on screen. Wait for its full duration so the next action sees a stable screen.
+            sleep(durationInMs);
         }
 
         /**
@@ -897,6 +900,9 @@ namespace AppiumTest
             Log($"Swipe to top from point ({fromPoint.X}, {fromPoint.Y}) to point ({toPoint.X}, {toPoint.Y})");
 
             SwipeByPoint(fromPoint, toPoint, 100);
+            // A fast swipe triggers scroll inertia that keeps the content moving after the gesture ends.
+            // Wait for the screen to settle before interacting again.
+            sleep(Config.IdleDelayInMs);
         }
 
         /**
@@ -927,6 +933,9 @@ namespace AppiumTest
 
             Log($"Drag from point ({fromPoint.X}, {fromPoint.Y}) to point ({toPoint.X}, {toPoint.Y})");
             driver.PerformActions(new[] {sequence});
+            // PerformActions() returns once the gesture is dispatched; the drag animation still runs on screen.
+            // Wait for its full duration so the next action sees a stable screen.
+            sleep(duration);
         }
 
         public void SendKeys(string keys)

--- a/src/templates/java/TestBase.java
+++ b/src/templates/java/TestBase.java
@@ -757,6 +757,9 @@ public class TestBase {
         sequence.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
 
         driver.perform(Arrays.asList(sequence));
+        // perform() returns as soon as the gesture is dispatched, but the swipe animation
+        // is still running on screen. Wait for its full duration so the next action sees a stable screen.
+        sleep(durationInMs);
     }
 
     /**
@@ -767,6 +770,9 @@ public class TestBase {
         System.out.println(String.format("Swipe to top from point (%s, %s) to point (%s, %s)", fromPoint.x, fromPoint.y, toPoint.x, toPoint.y));
 
         swipeByPoint(fromPoint, toPoint, 100);
+        // A fast swipe triggers scroll inertia that keeps the content moving after the gesture ends.
+        // Wait for the screen to settle before interacting again.
+        sleep(Config.IDLE_DELAY_IN_MS);
     }
 
     /**
@@ -794,6 +800,9 @@ public class TestBase {
 
         System.out.println(String.format("Drag from point (%s, %s) to point (%s, %s)", fromPoint.x, fromPoint.y, toPoint.x, toPoint.y));
         driver.perform(Arrays.asList(sequence));
+        // perform() returns once the gesture is dispatched; the drag animation still runs on screen.
+        // Wait for its full duration so the next action sees a stable screen.
+        sleep(duration);
         return sequence;
     }
 

--- a/src/templates/nodejs/src/test/helper/base.js
+++ b/src/templates/nodejs/src/test/helper/base.js
@@ -732,12 +732,18 @@ export default class TestBase {
     ]
 
     await this._driver.actions(actions)
+    // actions() returns as soon as the gesture is dispatched, but the swipe animation
+    // is still running on screen. Wait for its full duration so the next action sees a stable screen.
+    await this.sleep(durationInMs)
   }
 
   async swipeToTop(fromPoint) {
     const toPoint = new Point(fromPoint.x, (await this.getScreenSize()).y - 10)
     console.log(`Swipe to top from point (${fromPoint.x}, ${fromPoint.y}) to point (${toPoint.x}, ${toPoint.y})`)
     await this.swipeByPoint(fromPoint, toPoint, 100)
+    // A fast swipe triggers scroll inertia that keeps the content moving after the gesture ends.
+    // Wait for the screen to settle before interacting again.
+    await this.sleep(Config.IDLE_DELAY_IN_MS)
   }
 
   async dragByPoint(fromPoint, toPoint) {
@@ -775,6 +781,9 @@ export default class TestBase {
 
     console.log(`Drag from point (${fromPoint.x}, ${fromPoint.y}) to point (${toPoint.x}, ${toPoint.y})`)
     await this._driver.actions(actions)
+    // actions() returns once the gesture is dispatched; the drag animation still runs on screen.
+    // Wait for its full duration so the next action sees a stable screen.
+    await this.sleep(duration)
   }
 
   async dragFromPoint(fromPoint, relativeOffsetX, relativeOffsetY) {

--- a/src/templates/python/test_base.py
+++ b/src/templates/python/test_base.py
@@ -497,6 +497,9 @@ class TestBase:
             f"point ({to_p['x']}, {to_p['y']}) with duration {duration}"
         )
         self._driver.swipe(from_p['x'], from_p['y'], to_p['x'], to_p['y'], duration)
+        # swipe() returns as soon as the gesture is dispatched, but the swipe animation
+        # is still running on screen. Wait for its full duration so the next action sees a stable screen.
+        self.sleep(duration)
 
     def swipe_from_point(self, from_point, relative_offset_x, relative_offset_y, duration_ms):
         screen = self.get_screen_size()
@@ -512,6 +515,9 @@ class TestBase:
             f"to point ({to_point['x']}, {to_point['y']})"
         )
         self._swipe(from_point, to_point, 100)
+        # A fast swipe triggers scroll inertia that keeps the content moving after the gesture ends.
+        # Wait for the screen to settle before interacting again.
+        self.sleep(Config.IDLE_DELAY_IN_MS)
 
     def drag_by_point(self, from_point, to_point):
         # Linear-velocity drag built as a single W3C pointer sequence so the
@@ -541,6 +547,9 @@ class TestBase:
             f"point ({to_point['x']}, {to_point['y']})"
         )
         actions.perform()
+        # perform() returns once the gesture is dispatched; the drag animation still runs on screen.
+        # Wait for its full duration so the next action sees a stable screen.
+        self.sleep(total_duration_ms)
 
     def drag_from_point(self, from_point, relative_offset_x, relative_offset_y):
         screen = self.get_screen_size()


### PR DESCRIPTION
## Problem

Generated tests intermittently fail a step or two after a swipe/scroll: the post-gesture command lands on the wrong element/coordinate, leaving the screen in an unexpected state, and a later element is not found.

## Root cause

The W3C gesture calls (`driver.perform(...)` / `driver.actions(...)` / `driver.swipe(...)`) return as soon as the gesture is **dispatched**, not when the swipe/scroll animation finishes. Scroll inertia keeps the content moving after the call returns, so the next recorded command executes against a still-scrolling screen.

This is **language-agnostic** — not specific to the Python client and unrelated to click-body shape or flex-correct (see KOB-53267 discussion).

## Fix

Add a post-gesture wait so each action sees a stable screen, in all four templates (`java`, `python`, `csharp`, `nodejs`):
- `sleep(duration)` after `swipeByPoint` / `_swipe` and after `drag`
- `sleep(IDLE_DELAY)` after the inertial `swipeToTop`

## Verification

Baseline session 8671449 (Pixel 8 Pro / Android 16, Kobiton Expense Tracker) — the recorded flow includes a scroll on the Add Expense form followed by taps; with the wait added, the post-scroll steps hit their targets and the run completes.

Jira: KOB-53267

🤖 Generated with [Claude Code](https://claude.com/claude-code)